### PR TITLE
Spelling

### DIFF
--- a/examples/updater.pl
+++ b/examples/updater.pl
@@ -152,7 +152,7 @@ sub _all_installed {
         ### as we're making assumptions about the length
         ### This solves rt.cpan issue #19738
 
-        ### John M. notes: On VMS cannonpath cannot currently handle
+        ### John M. notes: On VMS canonpath cannot currently handle
         ### the $dir values that are in UNIX format.
         $dir = File::Spec->canonpath( $dir ) unless ON_VMS;
 

--- a/examples/updater.pl
+++ b/examples/updater.pl
@@ -152,7 +152,7 @@ sub _all_installed {
         ### as we're making assumptions about the length
         ### This solves rt.cpan issue #19738
 
-        ### John M. notes: On VMS cannonpath can not currently handle
+        ### John M. notes: On VMS cannonpath cannot currently handle
         ### the $dir values that are in UNIX format.
         $dir = File::Spec->canonpath( $dir ) unless ON_VMS;
 

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB.pm
@@ -183,11 +183,11 @@ quite memory intensive.
 
 This source implementation does things slightly different.
 
-Instead of building an in-memory index, it queries the L<http://cpanmetadb.appspot.com/> 
+Instead of building an in-memory index, it queries the L<http://cpanmetadb.plackperl.org/> 
 website for module/distribution information as and when it is required
 by L<CPANPLUS>.
 
-The default CPANMetaDB site is L<http://cpanmetadb.appspot.com/>.
+The default CPANMetaDB site is L<http://cpanmetadb.plackperl.org/>.
 
 You may set the C<PERL5_CPANMETADB_URL> environment variable to an alternative if you wish.
 
@@ -228,7 +228,7 @@ L<CPANPLUS>
 
 L<CPANPLUS::Internals::Source>
 
-L<http://cpanmetadb.appspot.com/>
+L<http://cpanmetadb.plackperl.org/>
 
 L<CPANPLUS::Internals::Source::CPANIDX>
 

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -978,17 +978,17 @@ otherwise the results are undefined.
 
 =item local_addr ( $ip )
 
-Explicity select the local IP address.  0.0.0.0 (default) lets the system
+Explicitly select the local IP address.  0.0.0.0 (default) lets the system
 choose.
 
 =item local_port ( $port )
 
-Explicity select the local port.  0 (default and reccomended) lets the
+Explicitly select the local port.  0 (default and reccomended) lets the
 system choose.
 
 =item method ( $method )
 
-Explicity set the method.  Using prepare_post or reset overrides this
+Explicitly set the method.  Using prepare_post or reset overrides this
 setting.  Usual choices are GET, POST, PUT, HEAD
 
 =back

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -865,7 +865,7 @@ An example use to save a document to file is:
 
 At various stages of the request, callbacks may be used to modify the
 behaviour or to monitor the status of the request.  These work like the
-$data_callback parameter to request(), but are more verstaile.  Using
+$data_callback parameter to request(), but are more versatile.  Using
 set_callback disables $data_callback in request()
 
 The callbacks are called as: 

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -831,7 +831,7 @@ status code.  200 series status codes represent success, 300 represent
 temporary errors, 400 represent permanent errors, and 500 represent server
 errors.
 
-See F<http://www.w3.org/Protocols/HTTP/HTRESP.html> for detailled
+See F<http://www.w3.org/Protocols/HTTP/HTRESP.html> for detailed
 information about HTTP status codes.
 
 The $data_callback parameter, if used, is a way to filter the data as it is

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -930,7 +930,7 @@ of each header.
 
 =item body
 
-Returns the body of the document retured by the remote server.
+Returns the body of the document returned by the remote server.
 
 =item headers_array
 

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -983,7 +983,7 @@ choose.
 
 =item local_port ( $port )
 
-Explicitly select the local port.  0 (default and reccomended) lets the
+Explicitly select the local port.  0 (default and recommended) lets the
 system choose.
 
 =item method ( $method )

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -145,7 +145,7 @@ sub request
     return undef;
   }
   
-  # Setup the connection
+  # Set up the connection
   my $proto = getprotobyname('tcp');
   local *FH;
   socket(FH, PF_INET, SOCK_STREAM, $proto);

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -1030,7 +1030,7 @@ setting.  Usual choices are GET, POST, PUT, HEAD
 
     - FTP 
     - HTTPS (SSL)
-    - Authenitcation/Authorizaton/Proxy-Authorization
+    - Authentication/Authorizaton/Proxy-Authorization
       are not directly supported, and require MIME::Base64.
     - Redirects (Location) are not automatically followed
     - multipart/form-data POSTs are not directly supported (necessary

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -826,10 +826,10 @@ arguments.  A future version of HTTP::Lite might accept parameters.
 
 Initiates a request to the specified URL.
 
-Returns undef if an I/O error is encountered, otherwise the HTTP
-status code will be returned.  200 series status codes represent
-success, 300 represent temporary errors, 400 represent permanent
-errors, and 500 represent server errors.
+If an I/O error is encountered, return undef; otherwise, return the HTTP
+status code.  200 series status codes represent success, 300 represent
+temporary errors, 400 represent permanent errors, and 500 represent server
+errors.
 
 See F<http://www.w3.org/Protocols/HTTP/HTRESP.html> for detailled
 information about HTTP status codes.

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -885,7 +885,7 @@ The current phases are:
   content - return value is used as content and is sent to client.  Return
             undef to use the internal content defined by prepare_post().
             
-  content-done - content has been successfuly transmitted.
+  content-done - content has been successfully transmitted.
   
   data - A block of data has been received.  The data is referenced by
             $dataref.  The return value is dereferenced and replaces the

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/HTTP.pm
@@ -1030,7 +1030,7 @@ setting.  Usual choices are GET, POST, PUT, HEAD
 
     - FTP 
     - HTTPS (SSL)
-    - Authentication/Authorizaton/Proxy-Authorization
+    - Authentication/Authorization/Proxy-Authorization
       are not directly supported, and require MIME::Base64.
     - Redirects (Location) are not automatically followed
     - multipart/form-data POSTs are not directly supported (necessary

--- a/lib/CPANPLUS/Internals/Source/CPANMetaDB/Tie.pm
+++ b/lib/CPANPLUS/Internals/Source/CPANMetaDB/Tie.pm
@@ -175,6 +175,6 @@ L<CPANPLUS>
 
 L<CPANPLUS::Internals::Source>
 
-L<http://cpanmetadb.appspot.com/>
+L<http://cpanmetadb.plackperl.org/>
 
 =cut


### PR DESCRIPTION
I was trying to figure out when https://github.com/Perl-Toolchain-Gang/module-build-tiny/pull/37 would be available, so I was searching for `how does cpanmetadb update` and `cpanmetadb updates` and I ran across https://metacpan.org/pod/CPANPLUS::Internals::Source::CPANMetaDB -- the docs on the page made mention of http://cpanmetadb.appspot.com, but the internals were changed in https://github.com/bingos/cpanplus-internals-source-cpanmetadb/commit/84fe63ab1f07d4ee6fd7187c4d4e77688211ff3f to use http://cpanmetadb.plackperl.org/

The api is available as: https://cpanmetadb.plackperl.org/v1.0/package/Module::Build::Tiny (note the `https`), but thinking about whether this module can safely change from `http:` to `https:` was a bit much, so, I'm leaving that change out.

---

I understand that this repository hasn't been touched in over a decade, but I'm on a 🚆 and it was an easy PR to make while I waited for the newer module version to arrive.